### PR TITLE
悩み中は送信ボタンを押せなくした

### DIFF
--- a/HackAichi2024/HackAichi2024/Controllers/ChatBotViewController.swift
+++ b/HackAichi2024/HackAichi2024/Controllers/ChatBotViewController.swift
@@ -87,6 +87,8 @@ extension ChatBotViewController: InputBarAccessoryViewDelegate {
         let userMessage = Message(id: UUID(), sender: .user, content: text, sentAt: Date())
         messagesViewController?.messageList.append(ChatMessageType.new(sender: MessageSenderType.user, message: userMessage.content))
         messagesViewController?.messageInputBar.inputTextView.text = String()
+        self.messagesViewController?.messageInputBar.shouldManageSendButtonEnabledState = false
+        self.messagesViewController?.messageInputBar.sendButton.isEnabled = false
         self.messagesViewController?.setTypingIndicatorViewHidden(false, animated: true)
         DispatchQueue.main.asyncAfter(deadline: .now()+3, execute: {
             Task {
@@ -95,8 +97,12 @@ extension ChatBotViewController: InputBarAccessoryViewDelegate {
                     DispatchQueue.main.async {
                         self.messagesViewController?.messageList.append(ChatMessageType.new(sender: MessageSenderType.character, message: response.content))
                     }
+                    self.messagesViewController?.messageInputBar.shouldManageSendButtonEnabledState = true
+                    guard let isEmpty = self.messagesViewController?.messageInputBar.inputTextView.text.isEmpty else { return }
+                    if !isEmpty {
+                        self.messagesViewController?.messageInputBar.sendButton.isEnabled = true
+                    }
                 })
-                print(response)
             }
         })
     }


### PR DESCRIPTION
closes #32 

悩み中は送信ボタンを押せなくした

`shouldManageSendButtonEnabledState`が`true`の場合、
入力欄にテキストがあると送信ボタンの`isEnabled`が`true`に、ないと`false`になるっぽい。

なので、悩み中になったときに、
`shouldManageSendButtonEnabledState`を`false`にして、
送信ボタンの`isEnabled`を`false`にした。
そして、悩み中が終わったタイミングで
`shouldManageSendButtonEnabledState`を`true`にした。

これだけだと、悩み中に文字を入力していた場合は、悩み中が終わっても送信ボタンの`isEnabled`が`false`のままなので、
（入力欄のテキストが変わるたびに`isEnabled`が変化するので、文字を打つか消せば`true`にはなる）
入力欄にテキストがあれば、`isEnabled`を`true`にした

もっと良い書き方があれば教えてください！
確認お願いします！