### PR TITLE
Chatの状態に応じてCharacterImageViewの画像を変更する仕組みを実装

### DIFF
--- a/HackAichi2024/HackAichi2024.xcodeproj/project.pbxproj
+++ b/HackAichi2024/HackAichi2024.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		BFD3BD242C9E9CBC00E88814 /* ChatMessageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD3BD232C9E9CBC00E88814 /* ChatMessageType.swift */; };
 		BFD3BD262C9EEAF300E88814 /* Color.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BFD3BD252C9EEAF300E88814 /* Color.xcassets */; };
 		BFD3BD2B2C9EF0C100E88814 /* UIColor+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD3BD2A2C9EF0C100E88814 /* UIColor+Extensions.swift */; };
+		BFD3BD2E2C9FCD7100E88814 /* CharacterImageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD3BD2D2C9FCD7100E88814 /* CharacterImageViewModel.swift */; };
+		BFD3BD302C9FCD9500E88814 /* CharacterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD3BD2F2C9FCD9500E88814 /* CharacterState.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -86,6 +88,8 @@
 		BFD3BD232C9E9CBC00E88814 /* ChatMessageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageType.swift; sourceTree = "<group>"; };
 		BFD3BD252C9EEAF300E88814 /* Color.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Color.xcassets; sourceTree = "<group>"; };
 		BFD3BD2A2C9EF0C100E88814 /* UIColor+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extensions.swift"; sourceTree = "<group>"; };
+		BFD3BD2D2C9FCD7100E88814 /* CharacterImageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterImageViewModel.swift; sourceTree = "<group>"; };
+		BFD3BD2F2C9FCD9500E88814 /* CharacterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterState.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -286,6 +290,8 @@
 			children = (
 				BFD3BD212C9E9C6400E88814 /* MessageSenderType.swift */,
 				BFD3BD232C9E9CBC00E88814 /* ChatMessageType.swift */,
+				BFD3BD2D2C9FCD7100E88814 /* CharacterImageViewModel.swift */,
+				BFD3BD2F2C9FCD9500E88814 /* CharacterState.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -385,8 +391,10 @@
 				346D783A2C9E5923007EDD43 /* LoadQAEntriesImpl.swift in Sources */,
 				34E670482C97CB4500BD8DA8 /* AppleEmbeddingService.swift in Sources */,
 				34E6701C2C97188F00BD8DA8 /* QAEntryRepository.swift in Sources */,
+				BFD3BD2E2C9FCD7100E88814 /* CharacterImageViewModel.swift in Sources */,
 				BFC1EEB42C9C7992007E3A9B /* ChatBotViewController.swift in Sources */,
 				34E6704A2C97DA2A00BD8DA8 /* LoadQAEntriesUseCase.swift in Sources */,
+				BFD3BD302C9FCD9500E88814 /* CharacterState.swift in Sources */,
 				BFD3BD222C9E9C6400E88814 /* MessageSenderType.swift in Sources */,
 				BFD3BD2B2C9EF0C100E88814 /* UIColor+Extensions.swift in Sources */,
 				34E670552C981D7A00BD8DA8 /* LoadFileService.swift in Sources */,

--- a/HackAichi2024/HackAichi2024/Models/CharacterImageViewModel.swift
+++ b/HackAichi2024/HackAichi2024/Models/CharacterImageViewModel.swift
@@ -1,0 +1,34 @@
+//
+//  CharacterImageViewModel.swift
+//  HackAichi2024
+//
+//  Created by jun on 2024/09/22.
+//
+
+import UIKit
+
+class CharacterImageViewModel {
+    var state: CharacterState {
+        didSet {
+            setImage(state: state)
+        }
+    }
+    
+    var image: UIImage!
+    
+    init(state: CharacterState) {
+        self.state = state
+        setImage(state: state)
+    }
+    
+    private func setImage(state: CharacterState) {
+        switch state {
+        case .welcome:
+            image = UIImage(systemName: "1.circle")
+        case .thinking:
+            image = UIImage(systemName: "2.circle")
+        case .answer:
+            image = UIImage(systemName: "3.circle")
+        }
+    }
+}

--- a/HackAichi2024/HackAichi2024/Models/CharacterState.swift
+++ b/HackAichi2024/HackAichi2024/Models/CharacterState.swift
@@ -1,0 +1,25 @@
+//
+//  CharacterState.swift
+//  HackAichi2024
+//
+//  Created by jun on 2024/09/22.
+//
+
+import Foundation
+
+enum CharacterState {
+    case welcome
+    case thinking
+    case answer
+    
+    mutating func goNextState() {
+        switch self {
+        case .welcome:
+            self = .thinking
+        case .thinking:
+            self = .answer
+        case .answer:
+            self = .thinking
+        }
+    }
+}

--- a/HackAichi2024/HackAichi2024/Views/CharacterImageView.swift
+++ b/HackAichi2024/HackAichi2024/Views/CharacterImageView.swift
@@ -8,10 +8,11 @@
 import UIKit
 
 class CharacterImageView: UIImageView {
-
-    override init(image: UIImage?) {
-        super.init(image: image)
+    
+    init(viewModel: CharacterImageViewModel) {
+        super.init(frame: .zero)
         setUpImageView()
+        apply(viewModel: viewModel)
     }
     
     required init?(coder: NSCoder) {
@@ -21,5 +22,9 @@ class CharacterImageView: UIImageView {
     private func setUpImageView() {
         self.contentMode = .scaleAspectFit
         self.translatesAutoresizingMaskIntoConstraints = false
+    }
+    
+    func apply(viewModel: CharacterImageViewModel) {
+        self.image = viewModel.image
     }
 }


### PR DESCRIPTION
closes #34 

初期状態（welcome）（１の画像）
悩み中（thinking）（２の画像）
答え（answer）（３の画像）
の３つの状況に応じて、キャラの画像や動画を差し替える仕組みを実装
（後ほど、答えは答えられたパターンとわからなかったパターンにわけたい）
（ここでは、キャラの画像の代わりに、SFSymbolの数字の画像使ってます）

CharacterImageViewのViewModelを作成して、ChatBotViewControllerでViewにViewModelを適用させる

以上を、一旦、実装してみた

１の画像->送信->２の画像->答え出る->３の画像->送信->２の画像　以下２の画像と３の画像の繰り返しになるはず

確認お願いします！
